### PR TITLE
Add final flag for maps

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,6 +26,7 @@ interface WIC_Map_Backend {
   date: string;
   uploader: string;
   version: number;
+  final: boolean;
 }
 
 class WIC_Database_Backend {
@@ -40,6 +41,11 @@ class WIC_Database_Backend {
     try {
       const data = JSON.parse(await fs.readFileSync(dataFile, 'utf8'));
       this.maps = data.maps;
+      for (const name in this.maps) {
+        if (this.maps[name].final === undefined) {
+          this.maps[name].final = false;
+        }
+      }
     } catch (error) {
       this.maps = {};
       console.log('no cache file found, building')
@@ -81,7 +87,8 @@ class WIC_Database_Backend {
         hash,
         date: this.formatDate(new Date()),
         uploader: uploader,
-        version: 1
+        version: 1,
+        final: false
       };
     }
   }

--- a/set-final.ts
+++ b/set-final.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+
+const mapName = process.argv[2];
+if (!mapName) {
+  console.error('Usage: bun run set-final.ts <map-name>');
+  process.exit(1);
+}
+
+const dataFile = './backend/_data.json';
+
+let data: any;
+try {
+  data = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+} catch (err) {
+  console.error('Could not read', dataFile);
+  process.exit(1);
+}
+
+if (!data.maps || !data.maps[mapName]) {
+  console.error(`Map ${mapName} not found in data file.`);
+  process.exit(1);
+}
+
+data.maps[mapName].final = true;
+fs.writeFileSync(dataFile, JSON.stringify(data, null, 2));
+console.log(`Map ${mapName} marked as final.`);
+

--- a/src/components/maps/main.vue
+++ b/src/components/maps/main.vue
@@ -55,9 +55,9 @@ const init = async () => {
 
   // init LIVE maps
   const remote = (await axios.get(CONFIG.API_URL + '/maps/data')).data
-  remoteData = remote
+  remoteData = _.pickBy(remote, (map) => !map.final)
 
-  let promises = _.map(remote, async (map) => {
+  let promises = _.map(remoteData, async (map) => {
     let status: WIC_Map_Status;
     if (!_.includes(local, map.name)) {
       status = WIC_Map_Status.MISSING
@@ -78,7 +78,8 @@ const init = async () => {
       date: map.date,
       uploader: map.uploader,
       version: map.version,
-      size
+      size,
+      final: map.final
     } as WIC_Map_Frontend
 
     state.value.mapsLive.push(data)

--- a/src/lib/wic-map.ts
+++ b/src/lib/wic-map.ts
@@ -14,6 +14,7 @@ export interface WIC_Map_Backend {
   date: string;
   version: number;
   uploader: string;
+  final: boolean;
 }
 export interface WIC_Map_Frontend extends WIC_Map_Backend {
   status: WIC_Map_Status


### PR DESCRIPTION
## Summary
- support marking maps as final
- expose `final` field in map interfaces
- propagate `final` through backend and frontend
- provide `set-final.ts` utility script
- filter finalized maps out of the map list

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68581bd3531c83308172459f855d3d74